### PR TITLE
Song Redirection

### DIFF
--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/MusicActivity.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/MusicActivity.kt
@@ -258,7 +258,7 @@ class MusicActivity : AppCompatActivity() {
     @EntryPoint
     @InstallIn(ActivityComponent::class)
     interface ViewModelFactoryProvider {
-        fun noteDetailViewModelFactory(): ReleaseScreenViewModel.ReleaseScreenViewModelFactory
+        //fun noteDetailViewModelFactory(): ReleaseScreenViewModel.ReleaseScreenViewModelFactory
 
         fun profileScreenViewModelFactory(): ProfileScreenViewModel.ProfileScreenViewModelFactory
     }

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/cache/CacheDao.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/cache/CacheDao.kt
@@ -2,6 +2,7 @@ package nl.tudelft.trustchain.musicdao.core.cache
 
 import androidx.lifecycle.LiveData
 import androidx.room.*
+import kotlinx.coroutines.flow.Flow
 import nl.tudelft.trustchain.musicdao.core.cache.entities.AlbumEntity
 import nl.tudelft.trustchain.musicdao.core.cache.entities.MusicLikeEntity
 
@@ -42,4 +43,7 @@ interface CacheDao {
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertMusicLike(musicLike: MusicLikeEntity)
+
+    @Query("SELECT EXISTS(SELECT 1 FROM MusicLikeEntity WHERE likedMusicId = :songId AND name = :myId)")
+    fun isSongLikedByMe(songId: String, myId: String): Flow<Boolean>
 }

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/ipv8/blocks/musicLike/MusicLikeBlockRepository.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/ipv8/blocks/musicLike/MusicLikeBlockRepository.kt
@@ -15,6 +15,7 @@ constructor(
     private val musicLikeBlockValidator: MusicLikeBlockValidator
 ) {
 
+    public val myPeerPublicKey = musicCommunity.myPeer.publicKey.keyToBin().toHex()
 
     suspend fun getOrCrawl(songId: String): List<MusicLikeBlock>? {
         val block = get(songId)
@@ -79,8 +80,8 @@ constructor(
     fun create(create: CreateMusicLikeBlock): TrustChainBlock? {
         val transaction =
             mutableMapOf(
-                "publicKey" to musicCommunity.myPeer.publicKey.keyToBin().toHex(),
-                "name" to create.name,
+                "publicKey" to myPeerPublicKey,
+                "name" to myPeerPublicKey,
                 "likedMusicId" to create.likedMusicId,
                 "protocolVersion" to Constants.PROTOCOL_VERSION
             )
@@ -102,7 +103,6 @@ constructor(
 
     companion object {
         data class CreateMusicLikeBlock(
-            val name: String,
             val likedMusicId: String
         )
     }

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/repositories/model/MusicLike.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/repositories/model/MusicLike.kt
@@ -5,4 +5,12 @@ class MusicLike (
     val name: String,
     val likedMusicId: String,
     val protocolVersion: String
-)
+) {
+
+    // TODO: Use a better ID generation to reduce overlap
+    companion object {
+        fun musicLikeIdFromSong(track: Song): String {
+            return track.title + "_" + track.artist
+        }
+    }
+}

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/components/player/PlayerViewModel.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/components/player/PlayerViewModel.kt
@@ -6,7 +6,6 @@ import android.content.Context
 import android.net.Uri
 import android.util.Log
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import nl.tudelft.trustchain.musicdao.core.repositories.model.Song
 import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.MediaItem
@@ -16,6 +15,7 @@ import com.google.android.exoplayer2.upstream.DataSource
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import nl.tudelft.trustchain.musicdao.core.repositories.MusicLikeRepository
@@ -51,14 +51,6 @@ class PlayerViewModel @Inject constructor(
             .createMediaSource(mediaItem)
     }
 
-    suspend fun likeMusic(
-        track: Song,
-    ) {
-        val name = "Test Person"
-        Log.d("MusicLike", "$name attempts to like ${track.title}")
-        musicLikeRepository.createMusicLike(name, track.title)
-        Log.d("MusicLike", "$name liked ${track.title}")
-    }
 
     fun playDownloadedTrack(
         track: Song,

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/navigation/AppNavigation.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/navigation/AppNavigation.kt
@@ -204,17 +204,9 @@ fun AppNavigation(
             }
             composable(
                 Screen.Release.route,
-                arguments =
-                    listOf(
-                        navArgument("releaseId") {
-                            type = NavType.StringType
-                        }
-                    )
+                arguments = listOf(navArgument("releaseId") { type = NavType.StringType })
             ) { navBackStackEntry ->
                 ReleaseScreen(
-                    navBackStackEntry.arguments?.getString(
-                        "releaseId"
-                    )!!,
                     playerViewModel = playerViewModel,
                     navController = navController
                 )

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/navigation/AppNavigation.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/navigation/AppNavigation.kt
@@ -71,10 +71,12 @@ fun AppNavigation(
             }
             composable(Screen.Leaderboard.route) {
                 val searchScreenViewModel: nl.tudelft.trustchain.musicdao.ui.screens.search.SearchScreenViewModel = hiltViewModel()
+                val leaderboardViewModel: nl.tudelft.trustchain.musicdao.ui.screens.leaderboard.LeaderboardViewModel = hiltViewModel()
                 val albums = searchScreenViewModel.searchResult.collectAsState(listOf()).value
                 nl.tudelft.trustchain.musicdao.ui.screens.leaderboard.LeaderboardScreen(
                     albums = albums,
-                    navController = navController
+                    navController = navController,
+                    musicLikeRepository = leaderboardViewModel.musicLikeRepository
                 )
             }
             composable(Screen.Search.route) {

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/navigation/AppNavigation.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/navigation/AppNavigation.kt
@@ -39,6 +39,7 @@ import nl.tudelft.trustchain.musicdao.ui.screens.profile.MyProfileScreen
 import nl.tudelft.trustchain.musicdao.ui.screens.profile.MyProfileScreenViewModel
 import nl.tudelft.trustchain.musicdao.ui.screens.profile.ProfileScreen
 import nl.tudelft.trustchain.musicdao.ui.screens.profileMenu.ProfileMenuScreen
+import androidx.compose.runtime.collectAsState
 
 @ExperimentalAnimationApi
 @ExperimentalFoundationApi
@@ -66,6 +67,14 @@ fun AppNavigation(
                 HomeScreen(
                     navController = navController,
                     screenViewModel = searchScreenViewModel
+                )
+            }
+            composable(Screen.Leaderboard.route) {
+                val searchScreenViewModel: nl.tudelft.trustchain.musicdao.ui.screens.search.SearchScreenViewModel = hiltViewModel()
+                val albums = searchScreenViewModel.searchResult.collectAsState(listOf()).value
+                nl.tudelft.trustchain.musicdao.ui.screens.leaderboard.LeaderboardScreen(
+                    albums = albums,
+                    navController = navController
                 )
             }
             composable(Screen.Search.route) {

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/navigation/BottomNavigationBar.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/navigation/BottomNavigationBar.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.runtime.*
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavHostController
@@ -23,7 +24,8 @@ fun BottomNavigationBar(navController: NavHostController) {
             BottomNavigationItem("Home", Screen.Home.route, Icons.Filled.Home),
             BottomNavigationItem("Creator", Screen.CreatorMenu.route, Icons.Filled.Person),
             BottomNavigationItem("DAO", Screen.DaoRoute.route, Icons.Filled.Person),
-            BottomNavigationItem("Debug", Screen.Debug.route, Icons.Filled.Build)
+            BottomNavigationItem("Debug", Screen.Debug.route, Icons.Filled.Build),
+            BottomNavigationItem("Leaderboard", Screen.Leaderboard.route, Icons.Filled.Star)
         )
 
     BottomNavigation {

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/navigation/Screen.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/navigation/Screen.kt
@@ -3,6 +3,8 @@ package nl.tudelft.trustchain.musicdao.ui.navigation
 sealed class Screen(val route: String) {
     object Home : Screen("home")
 
+    object Leaderboard : Screen("leaderboard")
+
     object Release : Screen("release/{releaseId}") {
         fun createRoute(releaseId: String) = "release/$releaseId"
     }

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/navigation/Screen.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/navigation/Screen.kt
@@ -5,8 +5,19 @@ sealed class Screen(val route: String) {
 
     object Leaderboard : Screen("leaderboard")
 
-    object Release : Screen("release/{releaseId}") {
-        fun createRoute(releaseId: String) = "release/$releaseId"
+    object Release : Screen("release/{releaseId}?title={title}&artist={artist}") {
+
+        // If a specific song (title + artist) is provided, include them as query parameters.
+        // Otherwise, just navigate to the album with its ID.
+        fun createRoute(releaseId: String, title: String? = null, artist: String? = null): String {
+            return if (title != null && artist != null) {
+                // Include song metadata in the route to support auto-play (if provided)
+                "release/$releaseId?title=$title&artist=$artist"
+            } else {
+                // Default navigation to the album without song selection
+                "release/$releaseId"
+            }
+        }
     }
 
     object Search : Screen("search")

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/leaderboard/LeaderboardScreen.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/leaderboard/LeaderboardScreen.kt
@@ -12,6 +12,7 @@ import nl.tudelft.trustchain.musicdao.core.repositories.model.Album
 import nl.tudelft.trustchain.musicdao.core.repositories.model.Song
 import androidx.compose.ui.text.style.TextOverflow
 import nl.tudelft.trustchain.musicdao.core.repositories.MusicLikeRepository
+import nl.tudelft.trustchain.musicdao.core.repositories.model.MusicLike
 
 @Composable
 fun LeaderboardScreen(
@@ -19,19 +20,20 @@ fun LeaderboardScreen(
     navController: NavController,
     musicLikeRepository: MusicLikeRepository
 ) {
-    var likesByTitle by remember { mutableStateOf<Map<String, Int>>(emptyMap()) }
+    var likesByMusicId by remember { mutableStateOf<Map<String, Int>>(emptyMap()) }
 
     LaunchedEffect(Unit) {
         // Fetch all likes from the repository
         val likes = musicLikeRepository.getLikes()
         // Group and count likes by likedMusicId (track.title in current logic)
-        likesByTitle = likes.groupingBy { it.likedMusicId }.eachCount()
+        likesByMusicId = likes.groupingBy { it.likedMusicId }.eachCount()
     }
 
     val songsWithLikes = albums
         .flatMap { it.songs.orEmpty() }
+        .distinctBy { song -> song.artist to song.title }
         .map { song ->
-            val likeCount = likesByTitle[song.title] ?: 0
+            val likeCount = likesByMusicId[MusicLike.musicLikeIdFromSong(song)] ?: 0
             song to likeCount
         }
         .sortedByDescending { it.second }

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/leaderboard/LeaderboardScreen.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/leaderboard/LeaderboardScreen.kt
@@ -12,7 +12,6 @@ import androidx.navigation.NavController
 import nl.tudelft.trustchain.musicdao.core.repositories.model.Album
 import nl.tudelft.trustchain.musicdao.core.repositories.model.Song
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.constraintlayout.motion.widget.MotionScene.Transition.TransitionOnClick
 import nl.tudelft.trustchain.musicdao.core.repositories.MusicLikeRepository
 import nl.tudelft.trustchain.musicdao.core.repositories.model.MusicLike
 import nl.tudelft.trustchain.musicdao.ui.navigation.Screen

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/leaderboard/LeaderboardScreen.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/leaderboard/LeaderboardScreen.kt
@@ -11,16 +11,28 @@ import androidx.navigation.NavController
 import nl.tudelft.trustchain.musicdao.core.repositories.model.Album
 import nl.tudelft.trustchain.musicdao.core.repositories.model.Song
 import androidx.compose.ui.text.style.TextOverflow
+import nl.tudelft.trustchain.musicdao.core.repositories.MusicLikeRepository
 
 @Composable
 fun LeaderboardScreen(
     albums: List<Album>,
-    navController: NavController
+    navController: NavController,
+    musicLikeRepository: MusicLikeRepository
 ) {
+    var likesByTitle by remember { mutableStateOf<Map<String, Int>>(emptyMap()) }
+
+    LaunchedEffect(Unit) {
+        // Fetch all likes from the repository
+        val likes = musicLikeRepository.getLikes()
+        // Group and count likes by likedMusicId (track.title in current logic)
+        likesByTitle = likes.groupingBy { it.likedMusicId }.eachCount()
+    }
+
     val songsWithLikes = albums
         .flatMap { it.songs.orEmpty() }
         .map { song ->
-            song to (1..9).random()
+            val likeCount = likesByTitle[song.title] ?: 0
+            song to likeCount
         }
         .sortedByDescending { it.second }
 

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/leaderboard/LeaderboardScreen.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/leaderboard/LeaderboardScreen.kt
@@ -1,5 +1,6 @@
 package nl.tudelft.trustchain.musicdao.ui.screens.leaderboard
 
+import java.util.Base64
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -70,7 +71,11 @@ fun LeaderboardScreen(
                     likes = likes,
                     rank = index + 1,
                     onClick = {
-                        navController.navigate(Screen.Release.createRoute(albumId)) // Handler to navigate to the album screen
+                        navController.currentBackStackEntry?.savedStateHandle?.apply {
+                            set("songTitle", song.title) // Stores the clicked song’s info so
+                            set("songArtist", song.artist) // the next screen can access it.
+                        }
+                        navController.navigate(Screen.Release.createRoute(albumId)) // Navigate to the album
                     }
                 )
                 Divider()

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/leaderboard/LeaderboardScreen.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/leaderboard/LeaderboardScreen.kt
@@ -1,5 +1,6 @@
 package nl.tudelft.trustchain.musicdao.ui.screens.leaderboard
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -11,8 +12,10 @@ import androidx.navigation.NavController
 import nl.tudelft.trustchain.musicdao.core.repositories.model.Album
 import nl.tudelft.trustchain.musicdao.core.repositories.model.Song
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.constraintlayout.motion.widget.MotionScene.Transition.TransitionOnClick
 import nl.tudelft.trustchain.musicdao.core.repositories.MusicLikeRepository
 import nl.tudelft.trustchain.musicdao.core.repositories.model.MusicLike
+import nl.tudelft.trustchain.musicdao.ui.navigation.Screen
 
 @Composable
 fun LeaderboardScreen(
@@ -57,10 +60,19 @@ fun LeaderboardScreen(
                 Divider()
             }
             itemsIndexed(songsWithLikes) { index, (song, likes) ->
+                // Find the album this song belongs to
+                val album = albums.firstOrNull {
+                    it.songs?.any { s -> s.title ==  song.title && s.artist == song.artist } == true
+                }
+                val albumId = album?.id ?: return@itemsIndexed
+
                 LeaderboardListItem(
                     song = song,
                     likes = likes,
-                    rank = index + 1
+                    rank = index + 1,
+                    onClick = {
+                        navController.navigate(Screen.Release.createRoute(albumId)) // Handler to navigate to the album screen
+                    }
                 )
                 Divider()
             }
@@ -80,7 +92,8 @@ fun LeaderboardScreen(
 fun LeaderboardListItem(
     song: Song,
     likes: Int,
-    rank: Int
+    rank: Int,
+    onClick: () -> Unit
 ) {
     ListItem(
         text = {
@@ -102,6 +115,7 @@ fun LeaderboardListItem(
                 "$likes likes",
                 style = MaterialTheme.typography.body1
             )
-        }
+        },
+        modifier = Modifier.clickable { onClick() } // Handle click to trigger navigation
     )
 }

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/leaderboard/LeaderboardScreen.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/leaderboard/LeaderboardScreen.kt
@@ -1,0 +1,93 @@
+package nl.tudelft.trustchain.musicdao.ui.screens.leaderboard
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import nl.tudelft.trustchain.musicdao.core.repositories.model.Album
+import nl.tudelft.trustchain.musicdao.core.repositories.model.Song
+import androidx.compose.ui.text.style.TextOverflow
+
+@Composable
+fun LeaderboardScreen(
+    albums: List<Album>,
+    navController: NavController
+) {
+    val songsWithLikes = albums
+        .flatMap { it.songs.orEmpty() }
+        .map { song ->
+            song to (1..9).random()
+        }
+        .sortedByDescending { it.second }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text("Leaderboard")
+                }
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+        ) {
+            item(0) {
+                Divider()
+            }
+            itemsIndexed(songsWithLikes) { index, (song, likes) ->
+                LeaderboardListItem(
+                    song = song,
+                    likes = likes,
+                    rank = index + 1
+                )
+                Divider()
+            }
+            if (songsWithLikes.isNotEmpty()) {
+                item("end") {
+                    Column(
+                        modifier = Modifier.height(100.dp)
+                    ) {}
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun LeaderboardListItem(
+    song: Song,
+    likes: Int,
+    rank: Int
+) {
+    ListItem(
+        text = {
+            Text(
+                "$rank. ${song.title}",
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        },
+        secondaryText = {
+            Text(
+                song.artist,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        },
+        trailing = {
+            Text(
+                "$likes likes",
+                style = MaterialTheme.typography.body1
+            )
+        }
+    )
+}

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/leaderboard/LeaderboardViewModel.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/leaderboard/LeaderboardViewModel.kt
@@ -1,0 +1,11 @@
+package nl.tudelft.trustchain.musicdao.ui.screens.leaderboard
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import nl.tudelft.trustchain.musicdao.core.repositories.MusicLikeRepository
+import javax.inject.Inject
+
+@HiltViewModel
+class LeaderboardViewModel @Inject constructor(
+    val musicLikeRepository: MusicLikeRepository
+) : ViewModel()

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/release/ReleaseScreen.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/release/ReleaseScreen.kt
@@ -93,6 +93,26 @@ fun ReleaseScreen(
     val scrollState = rememberScrollState()
 
     albumState?.let { album ->
+
+        // Get the values that has been stored from the previous screen
+        val songTitle = navController.previousBackStackEntry?.savedStateHandle?.get<String>("songTitle")
+        val songArtist = navController.previousBackStackEntry?.savedStateHandle?.get<String>("songArtist")
+
+        LaunchedEffect(songTitle, songArtist) {
+            if (songTitle != null && songArtist != null) {
+                val songToPlay = album.songs?.firstOrNull {
+                    it.title == songTitle && it.artist == songArtist
+                }
+                if (songToPlay != null) {
+                    playerViewModel.playDownloadedTrack(songToPlay, album.cover) // Starts the playback
+                }
+
+                // Clean up state so it doesn't auto-trigger again
+                navController.previousBackStackEntry?.savedStateHandle?.remove<String>("songTitle")
+                navController.previousBackStackEntry?.savedStateHandle?.remove<String>("songArtist")
+            }
+        }
+
         LaunchedEffect(
             key1 = playerViewModel,
             block = {

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/release/ReleaseScreenViewModel.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/release/ReleaseScreenViewModel.kt
@@ -1,5 +1,6 @@
 package nl.tudelft.trustchain.musicdao.ui.screens.release
 
+import android.util.Log
 import androidx.lifecycle.*
 import nl.tudelft.trustchain.musicdao.core.cache.CacheDatabase
 import nl.tudelft.trustchain.musicdao.core.cache.entities.AlbumEntity
@@ -9,64 +10,72 @@ import nl.tudelft.trustchain.musicdao.core.torrent.status.TorrentStatus
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import nl.tudelft.trustchain.musicdao.core.repositories.MusicLikeRepository
+import nl.tudelft.trustchain.musicdao.core.repositories.model.Song
+import javax.inject.Inject
 
 @OptIn(DelicateCoroutinesApi::class)
-class ReleaseScreenViewModel
-    @AssistedInject
-    constructor(
-        @Assisted private val releaseId: String,
-        private val database: CacheDatabase,
-        private val torrentEngine: TorrentEngine,
-    ) : ViewModel() {
-        @AssistedFactory
-        interface ReleaseScreenViewModelFactory {
-            fun create(releaseId: String): ReleaseScreenViewModel
-        }
+@HiltViewModel
+class ReleaseScreenViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val database: CacheDatabase,
+    private val torrentEngine: TorrentEngine,
+    private val musicLikeRepository: MusicLikeRepository
+) : ViewModel() {
 
-        companion object {
-            fun provideFactory(
-                assistedFactory: ReleaseScreenViewModelFactory,
-                releaseId: String
-            ): ViewModelProvider.Factory =
-                object : ViewModelProvider.Factory {
-                    override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                        @Suppress("UNCHECKED_CAST")
-                        return assistedFactory.create(releaseId) as T
-                    }
+    private val releaseId: String = checkNotNull(savedStateHandle["releaseId"])
+
+
+    private var releaseLiveData: LiveData<AlbumEntity> = MutableLiveData(null)
+    var saturatedReleaseState: LiveData<Album?> = MutableLiveData()
+
+    private val _torrentState: MutableStateFlow<TorrentStatus?> = MutableStateFlow(null)
+    val torrentState: StateFlow<TorrentStatus?> = _torrentState
+
+    init {
+        viewModelScope.launch {
+            releaseLiveData = database.dao.getLiveData(releaseId)
+            saturatedReleaseState = releaseLiveData.map { it.toAlbum() }
+
+            val release = database.dao.get(releaseId)
+
+            release.let { _release ->
+                if (!_release.isDownloaded) {
+                    torrentEngine.download(_release.magnet)
                 }
-        }
 
-        private var releaseLiveData: LiveData<AlbumEntity> = MutableLiveData(null)
-        var saturatedReleaseState: LiveData<Album?> = MutableLiveData()
-
-        private val _torrentState: MutableStateFlow<TorrentStatus?> = MutableStateFlow(null)
-        val torrentState: StateFlow<TorrentStatus?> = _torrentState
-
-        init {
-            viewModelScope.launch {
-                releaseLiveData = database.dao.getLiveData(releaseId)
-                saturatedReleaseState = releaseLiveData.map { it.toAlbum() }
-
-                val release = database.dao.get(releaseId)
-
-                release.let { _release ->
-                    if (!_release.isDownloaded) {
-                        torrentEngine.download(_release.magnet)
+                while (isActive) {
+                    if (_release.infoHash != null) {
+                        _torrentState.value = torrentEngine.getTorrentStatus(_release.infoHash)
                     }
-
-                    while (isActive) {
-                        if (_release.infoHash != null) {
-                            _torrentState.value = torrentEngine.getTorrentStatus(_release.infoHash)
-                        }
-                        delay(1000L)
-                    }
+                    delay(1000L)
                 }
             }
         }
     }
+
+    suspend fun likeMusic(
+        track: Song,
+    ) {
+        val block = musicLikeRepository.createMusicLike(track)
+        if (block != null) {
+            Log.d("MusicLike", "${block.name} liked ${block.likedMusicId}")
+        }
+
+    }
+
+    fun isMusicLikedByMe(
+        track: Song,
+    ): Flow<Boolean> {
+        return musicLikeRepository.isSongLikedByMe(track)
+    }
+
+}


### PR DESCRIPTION
This PR implements two improvements to the leaderboard UX and resolves #9. First, clicking a song now navigates to the album that contains it. Second, the selected song starts playing automatically when the album screen loads.