### PR TITLE
Tags

### DIFF
--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/cache/CacheDao.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/cache/CacheDao.kt
@@ -5,7 +5,9 @@ import androidx.room.*
 import kotlinx.coroutines.flow.Flow
 import nl.tudelft.trustchain.musicdao.core.cache.entities.AlbumEntity
 import nl.tudelft.trustchain.musicdao.core.cache.entities.MusicLikeEntity
+import nl.tudelft.trustchain.musicdao.core.cache.entities.MusicTagEntity
 import nl.tudelft.trustchain.musicdao.core.ipv8.blocks.Constants
+import nl.tudelft.trustchain.musicdao.core.repositories.model.TagCount
 
 @Dao
 interface CacheDao {
@@ -63,6 +65,20 @@ interface CacheDao {
     @Query("SELECT EXISTS(SELECT 1 FROM MusicLikeEntity WHERE publicKey = :userPublicKey AND songName = :songName)")
     fun isSongLikedByUser(userPublicKey: String, songName: String): Flow<Boolean>
 
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun addTag(tag: MusicTagEntity)
+
+    @Query("DELETE FROM MusicTagEntity WHERE publicKey = :publicKey AND songName = :songName AND tag = :tag")
+    suspend fun removeTag(publicKey: String, songName: String, tag: String)
+
+    @Query("SELECT tag, COUNT(*) as count FROM MusicTagEntity WHERE songName = :songName GROUP BY tag ORDER BY count DESC LIMIT 3")
+    suspend fun getTopTagsForSong(songName: String): List<TagCount>
+
+    @Query("SELECT tag FROM MusicTagEntity WHERE publicKey = :publicKey AND songName = :songName")
+    suspend fun getUserTagsForSong(publicKey: String, songName: String): List<String>
+
+    @Query("SELECT * FROM MusicTagEntity WHERE publicKey = :publicKey")
+    suspend fun getUserTagsForAllSongs(publicKey: String): List<MusicTagEntity>
 
 //    @Query("SELECT * FROM MusicLikeEntity")
 //    suspend fun getAllMusicLikes(): List<MusicLikeEntity>

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/cache/CacheDatabase.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/cache/CacheDatabase.kt
@@ -7,11 +7,12 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import nl.tudelft.trustchain.musicdao.core.cache.entities.AlbumEntity
 import nl.tudelft.trustchain.musicdao.core.cache.entities.MusicLikeEntity
+import nl.tudelft.trustchain.musicdao.core.cache.entities.MusicTagEntity
 import nl.tudelft.trustchain.musicdao.core.cache.parser.Converters
 
 @Database(
-    entities = [AlbumEntity::class, MusicLikeEntity::class],
-    version = 7,
+    entities = [AlbumEntity::class, MusicLikeEntity::class, MusicTagEntity::class],
+    version = 8,
     exportSchema = false
 )
 @TypeConverters(Converters::class)

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/cache/CacheDatabase.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/cache/CacheDatabase.kt
@@ -11,7 +11,7 @@ import nl.tudelft.trustchain.musicdao.core.cache.entities.MusicTagEntity
 import nl.tudelft.trustchain.musicdao.core.cache.parser.Converters
 
 @Database(
-    entities = [AlbumEntity::class, MusicLikeEntity::class],
+    entities = [AlbumEntity::class, MusicLikeEntity::class, MusicTagEntity::class],
     version = 8,
     exportSchema = false
 )

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/cache/entities/MusicTagEntity.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/cache/entities/MusicTagEntity.kt
@@ -1,0 +1,21 @@
+package nl.tudelft.trustchain.musicdao.core.cache.entities
+
+import androidx.room.Entity
+import nl.tudelft.trustchain.musicdao.core.repositories.model.MusicTag
+
+@Entity(primaryKeys = ["publicKey", "songName", "tag"])
+data class MusicTagEntity(
+    val publicKey: String,
+    val songName: String,
+    val tag: String,
+    val protocolVersion: String
+) {
+    fun toMusicTag(): MusicTag {
+        return MusicTag(
+            publicKey = publicKey,
+            songName = songName,
+            tag = tag,
+            protocolVersion = protocolVersion
+        )
+    }
+}

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/ipv8/blocks/musicLike/MusicProfile.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/ipv8/blocks/musicLike/MusicProfile.kt
@@ -6,17 +6,26 @@ import nl.tudelft.ipv8.attestation.trustchain.TrustChainTransaction
 data class MusicProfile(
     val publicKey: String,
     val likedSongs: List<String>, // List of all liked song IDs
-    val protocolVersion: String
+    val protocolVersion: String,
+    val tags: Map<String, List<String>>
     // Additional fields like tags can be added in the future
 ) {
     companion object {
         const val BLOCK_TYPE = "music_profile"
 
         fun fromTrustChainTransaction(transaction: TrustChainTransaction): MusicProfile {
+            val rawTags = transaction["tags"] as? Map<*, *>
+            val tags = rawTags?.mapNotNull { (key, value) ->
+                if (key is String && value is List<*> && value.all { it is String })
+                    key to value.filterIsInstance<String>()
+                else null
+            }?.toMap() ?: emptyMap()
+
             return MusicProfile(
                 publicKey = transaction["publicKey"] as String,
                 likedSongs = (transaction["likedSongs"] as List<*>).filterIsInstance<String>(),
-                protocolVersion = transaction["protocolVersion"] as String
+                protocolVersion = transaction["protocolVersion"] as String,
+                tags = tags
             )
         }
 
@@ -24,7 +33,8 @@ data class MusicProfile(
             return mapOf(
                 "publicKey" to block.publicKey,
                 "likedSongs" to block.likedSongs, // Serialize liked songs
-                "protocolVersion" to block.protocolVersion
+                "protocolVersion" to block.protocolVersion,
+                "tags" to block.tags
                 // Additional data like tags can be added here in the future
             )
         }

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/ipv8/blocks/musicLike/MusicProfileBlockRepository.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/ipv8/blocks/musicLike/MusicProfileBlockRepository.kt
@@ -95,7 +95,8 @@ constructor(
             MusicProfile(
                 publicKey = myPeerPublicKey,
                 likedSongs = companion.allLikedSongs,
-                protocolVersion = Constants.PROTOCOL_VERSION
+                protocolVersion = Constants.PROTOCOL_VERSION,
+                tags = companion.allTags
             )
         )
         if (!musicProfileBlockValidator.validateTransaction(transaction)) {
@@ -116,7 +117,8 @@ constructor(
 
     companion object {
         data class MusicProfileCompanion(
-            val allLikedSongs: List<String>
+            val allLikedSongs: List<String>,
+            val allTags: Map<String, List<String>>
             // tags
         )
     }

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/ipv8/blocks/musicLike/MusicProfileBlockValidator.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/ipv8/blocks/musicLike/MusicProfileBlockValidator.kt
@@ -30,11 +30,20 @@ class MusicProfileBlockValidator
             val publicKey = transaction["publicKey"]
             val likedSongs = transaction["likedSongs"]
             val protocolVersion = transaction["protocolVersion"]
+            val tags = transaction["tags"]
+
+            val isValidTags = tags == null || (
+                tags is Map<*, *> &&
+                    tags.keys.all { it is String } &&
+                    tags.values.all { it is List<*> && it.all { tag -> tag is String } }
+                )
+
 
             return (
                 publicKey is String && publicKey.isNotEmpty() &&
                     likedSongs is List<*> && likedSongs.all { it is String } &&
-                    protocolVersion is String && protocolVersion == Constants.PROTOCOL_VERSION
+                    protocolVersion is String && protocolVersion == Constants.PROTOCOL_VERSION &&
+                    isValidTags
                 )
         }
         companion object {

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/repositories/MusicProfileRepository.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/repositories/MusicProfileRepository.kt
@@ -5,11 +5,13 @@ import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import nl.tudelft.trustchain.musicdao.core.cache.CacheDatabase
+import nl.tudelft.trustchain.musicdao.core.cache.entities.MusicTagEntity
 import nl.tudelft.trustchain.musicdao.core.ipv8.blocks.Constants.PROTOCOL_VERSION
 import nl.tudelft.trustchain.musicdao.core.ipv8.blocks.musicLike.MusicProfile
 import nl.tudelft.trustchain.musicdao.core.ipv8.blocks.musicLike.MusicProfileBlockRepository
 import nl.tudelft.trustchain.musicdao.core.repositories.model.MusicLike
 import nl.tudelft.trustchain.musicdao.core.repositories.model.Song
+import nl.tudelft.trustchain.musicdao.core.repositories.model.TagCount
 import javax.inject.Inject
 
 
@@ -65,7 +67,16 @@ constructor(
             database.dao.getAllLikedSongsByUser(musicProfileBlockRepository.myPeerPublicKey)
                 .firstOrNull() ?: emptyList()
         val likedSongsList = likedSongs.map { it.songName }.toList()
-        val companion = MusicProfileBlockRepository.Companion.MusicProfileCompanion(likedSongsList)
+
+        val allTags = database.dao.getUserTagsForAllSongs(musicProfileBlockRepository.myPeerPublicKey)
+            .groupBy { it.songName }
+            .mapValues { it.value.map { tag -> tag.tag }.take(3) }
+
+        val companion = MusicProfileBlockRepository.Companion.MusicProfileCompanion(
+            allLikedSongs = likedSongsList,
+            allTags = allTags
+        )
+
         val block = musicProfileBlockRepository.create(companion)
             ?.let { MusicProfile.fromTrustChainTransaction(it.transaction) }
 
@@ -73,6 +84,39 @@ constructor(
         return block
     }
 
+    suspend fun toggleTag(song: Song, tag: String): MusicProfile? {
+        val songId = MusicLike.musicLikeIdFromSong(song)
+        val userKey = musicProfileBlockRepository.myPeerPublicKey
+
+        val currentTags = database.dao.getUserTagsForSong(userKey, songId)
+        if (tag in currentTags) {
+            database.dao.removeTag(userKey, songId, tag)
+        } else if (currentTags.size < 3) {
+            database.dao.addTag(
+                MusicTagEntity(
+                    publicKey = userKey,
+                    songName = songId,
+                    tag = tag,
+                    protocolVersion = PROTOCOL_VERSION
+                )
+            )
+        }
+
+        val likedSongs = database.dao.getAllLikedSongsByUser(userKey)
+            .firstOrNull()?.map { it.songName } ?: emptyList()
+
+        val allTags = database.dao.getUserTagsForAllSongs(userKey)
+            .groupBy { it.songName }
+            .mapValues { entry -> entry.value.map { it.tag }.take(3) }
+
+        val companion = MusicProfileBlockRepository.Companion.MusicProfileCompanion(
+            allLikedSongs = likedSongs,
+            allTags = allTags
+        )
+
+        return musicProfileBlockRepository.create(companion)
+            ?.let { MusicProfile.fromTrustChainTransaction(it.transaction) }
+    }
 
     // For some reason, this function causes the updates to the local database to be lost
     @OptIn(DelicateCoroutinesApi::class)
@@ -110,6 +154,29 @@ constructor(
                     songName = song
                 )
             }
+
+            val remoteTags = block.tags
+            val localTags = database.dao.getUserTagsForAllSongs(userPublicKey)
+
+            val remoteTagTriples = remoteTags.flatMap { (song, tags) ->
+                tags.map { tag -> Triple(song, tag, userPublicKey) }
+            }.toSet()
+            val localTagTriples = localTags.map { Triple(it.songName, it.tag, it.publicKey) }.toSet()
+
+            val tagsToAdd = remoteTagTriples - localTagTriples
+            val tagsToRemove = localTagTriples - remoteTagTriples
+
+            for ((song, tag, pubKey) in tagsToAdd) {
+                Log.d("MusicProfile", "Inserting tag: $tag for song: $song from user: $userPublicKey")
+                database.dao.addTag(
+                    MusicTagEntity(pubKey, song, tag, PROTOCOL_VERSION)
+                )
+            }
+
+            for ((song, tag, pubKey) in tagsToRemove) {
+                database.dao.removeTag(pubKey, song, tag)
+            }
+
         }
     }
 //
@@ -135,5 +202,17 @@ constructor(
             MusicLike.musicLikeIdFromSong(track)
         )
     }
+
+    suspend fun getUserTagsForSong(song: Song): List<String> {
+        return database.dao.getUserTagsForSong(
+            musicProfileBlockRepository.myPeerPublicKey,
+            MusicLike.musicLikeIdFromSong(song)
+        )
+    }
+
+    suspend fun getTopTagsForSong(song: Song): List<TagCount> {
+        return database.dao.getTopTagsForSong(MusicLike.musicLikeIdFromSong(song))
+    }
+
 
 }

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/repositories/model/MusicTag.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/repositories/model/MusicTag.kt
@@ -1,0 +1,8 @@
+package nl.tudelft.trustchain.musicdao.core.repositories.model
+
+data class MusicTag(
+    val publicKey: String,
+    val songName: String,
+    val tag: String,
+    val protocolVersion: String
+)

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/repositories/model/TagCount.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/core/repositories/model/TagCount.kt
@@ -1,0 +1,6 @@
+package nl.tudelft.trustchain.musicdao.core.repositories.model
+
+data class TagCount(
+    val tag: String,
+    val count: Int
+)

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/leaderboard/LeaderboardScreen.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/leaderboard/LeaderboardScreen.kt
@@ -1,17 +1,21 @@
 package nl.tudelft.trustchain.musicdao.ui.screens.leaderboard
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import nl.tudelft.trustchain.musicdao.core.repositories.model.Album
 import nl.tudelft.trustchain.musicdao.core.repositories.model.Song
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.sp
 import nl.tudelft.trustchain.musicdao.core.repositories.MusicProfileRepository
 import nl.tudelft.trustchain.musicdao.core.repositories.model.MusicLike
 import nl.tudelft.trustchain.musicdao.ui.navigation.Screen
@@ -62,6 +66,12 @@ fun LeaderboardScreen(
                 Divider()
             }
             itemsIndexed(songsWithLikes) { index, (song, likes) ->
+                var topTags by remember { mutableStateOf<List<String>>(emptyList()) }
+
+                LaunchedEffect(song) {
+                    val tags = musicLikeRepository.getTopTagsForSong(song)
+                    topTags = tags.map { it.tag }
+                }
                 // Find the album this song belongs to
                 val album = albums.firstOrNull {
                     it.songs?.any { s -> s.title ==  song.title && s.artist == song.artist } == true
@@ -72,6 +82,7 @@ fun LeaderboardScreen(
                     song = song,
                     likes = likes,
                     rank = index + 1,
+                    topTags = topTags,
                     onClick = {
                         navController.currentBackStackEntry?.savedStateHandle?.apply {
                             set("songTitle", song.title) // Stores the clicked song’s info so
@@ -99,6 +110,7 @@ fun LeaderboardListItem(
     song: Song,
     likes: Int,
     rank: Int,
+    topTags: List<String>,
     onClick: () -> Unit
 ) {
     ListItem(
@@ -110,11 +122,35 @@ fun LeaderboardListItem(
             )
         },
         secondaryText = {
-            Text(
-                song.artist,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
+            Column {
+                Text(
+                    song.artist,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp),
+                    horizontalArrangement = Arrangement.Start
+                ) {
+                    topTags.forEach { tag ->
+                        Text(
+                            text = tag,
+                            fontSize = 12.sp,
+                            color = Color.Green,
+                            modifier = Modifier
+                                .padding(end = 5.dp)
+                                .border(
+                                    width = 1.dp,
+                                    color = Color(0xFF4CAF50),
+                                    shape = RoundedCornerShape(50)
+                                )
+                                .padding(horizontal = 7.dp, vertical = 4.dp)
+                        )
+                    }
+                }
+            }
         },
         trailing = {
             Text(

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/leaderboard/LeaderboardViewModel.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/leaderboard/LeaderboardViewModel.kt
@@ -3,9 +3,15 @@ package nl.tudelft.trustchain.musicdao.ui.screens.leaderboard
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import nl.tudelft.trustchain.musicdao.core.repositories.MusicProfileRepository
+import nl.tudelft.trustchain.musicdao.core.repositories.model.Song
+import nl.tudelft.trustchain.musicdao.core.repositories.model.TagCount
 import javax.inject.Inject
 
 @HiltViewModel
 class LeaderboardViewModel @Inject constructor(
     val musicLikeRepository: MusicProfileRepository
-) : ViewModel()
+) : ViewModel() {
+    suspend fun getTopTagsForSong(song: Song): List<TagCount> {
+        return musicLikeRepository.getTopTagsForSong(song)
+    }
+}

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/release/ReleaseScreen.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/release/ReleaseScreen.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -12,6 +13,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.List
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material.icons.outlined.Favorite
@@ -29,7 +31,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
@@ -170,6 +174,18 @@ fun ReleaseScreen(
                 if (!album.songs.isNullOrEmpty()) {
                     val files = album.songs
                     files.map {
+                        val selectedTags = remember { mutableStateListOf<String>() }
+                        var expanded by remember { mutableStateOf(false) }
+                        val genreOptions = listOf("Rock", "Jazz", "Pop", "Hip-Hop", "Electronic", "Classical")
+
+                        LaunchedEffect(it) {
+                            val newTags = viewModel.getSelectedTags(it)
+                            if (newTags.toSet() != selectedTags.toSet()) {
+                                selectedTags.clear()
+                                selectedTags.addAll(newTags)
+                            }
+                        }
+
                         val isPlayingModifier =
                             playingTrack.value?.let { current ->
                                 if (it.title == current.title) {
@@ -204,14 +220,52 @@ fun ReleaseScreen(
                                             tint = if (isLiked) MaterialTheme.colors.primary else Color.Gray // Green when liked, Gray when unliked
                                         )
                                     }
-                                    Icon(
-                                        imageVector = Icons.Default.MoreVert,
-                                        contentDescription = "More options"
-                                    )
+                                    IconButton(onClick = { expanded = true }) {
+                                        Icon(imageVector = Icons.Default.List, contentDescription = "Select Tags")
+                                    }
+                                    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                                        genreOptions.forEach { tag ->
+                                            val selected = tag in selectedTags
+                                            DropdownMenuItem(onClick = {
+                                                coroutineScope.launch {
+                                                    viewModel.toggleTag(it, tag)
+                                                    selectedTags.clear()
+                                                    selectedTags.addAll(viewModel.getSelectedTags(it))
+                                                }
+                                            }) {
+                                                Text(tag, color = if (selected) Color.Green else Color.Unspecified)
+                                            }
+                                        }
+                                    }
+
                                 }
                             },
                             modifier = Modifier.clickable { play(it, album.cover) }
                         )
+
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(start = 10.dp, top = .5.dp),
+                            horizontalArrangement = Arrangement.Start
+                        ) {
+                            selectedTags.forEach { tag ->
+                                Text(
+                                    text = tag,
+                                    fontSize = 12.sp,
+                                    color = Color.Green, // Green
+                                    modifier = Modifier
+                                        .padding(end = 5.dp)
+                                        .border(
+                                            width = 1.dp,
+                                            color = Color(0xFF4CAF50),
+                                            shape = RoundedCornerShape(50)
+                                        )
+                                        .padding(horizontal = 7.dp, vertical = 4.dp)
+                                )
+                            }
+                        }
+
                     }
                 } else {
                     if (torrentStatus != null) {

--- a/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/release/ReleaseScreenViewModel.kt
+++ b/musicdao/src/main/java/nl/tudelft/trustchain/musicdao/ui/screens/release/ReleaseScreenViewModel.kt
@@ -86,4 +86,13 @@ class ReleaseScreenViewModel @Inject constructor(
         return res
     }
 
+    suspend fun toggleTag(song: Song, tag: String) {
+        musicProfileRepository.toggleTag(song, tag)
+    }
+
+    suspend fun getSelectedTags(song: Song): List<String> {
+        return musicProfileRepository.getUserTagsForSong(song)
+    }
+
+
 }


### PR DESCRIPTION
This PR adds user-generated tagging support to the Release and Leaderboard screens, resolving issue #11. Users can now assign up to 3 tags per song from a dropdown list containing music genres, which are stored locally, synced via the music profile block, and aggregated across peers. In the Leaderboard, each song now displays the top 3 most frequently assigned tags among all users. UI updates and database changes are included.
